### PR TITLE
Added resize_to_fft_size function with docstring and unit test using pytest fixture

### DIFF
--- a/cut_to_fft.py
+++ b/cut_to_fft.py
@@ -1,0 +1,27 @@
+import numpy as np
+import pandas as pd
+
+def resize_to_fft_size(image_data):
+    """
+    Resize the input image (2D array) to the nearest power of two dimensions.
+    
+    Args:
+        image_data (pd.DataFrame): The input image data as a pandas DataFrame.
+        
+    Returns:
+        pd.DataFrame: The resized image data with dimensions as powers of two.
+    """
+    # Get current image dimensions
+    rows, cols = image_data.shape
+    
+    # Find the nearest power of two for rows and columns
+    new_rows = 2**int(np.floor(np.log2(rows)))
+    new_cols = 2**int(np.floor(np.log2(cols)))
+    
+    # Resize the image (either crop or pad the data)
+    if new_rows < rows and new_cols < cols:
+        resized_image = image_data.iloc[:new_rows, :new_cols]
+    else:
+        resized_image = image_data.reindex(index=range(new_rows), columns=range(new_cols), fill_value=0)
+    
+    return resized_image


### PR DESCRIPTION
#Linting
  - The code has been linted, and there are minimal linting errors.

## Contents
  -This pull request adds a new function, resize_to_fft_size, which resizes images to FFT-suitable dimensions (powers of 2) in preparation.py.
- The PR includes docstrings, pytest, unit tests, and fixtures to ensure consistent testing. 

Files Changed:
preparation.py: Added resize_to_fft_size function with docstrings.
test_preparation.py: Added unit test test_resize_to_fft_size 

Task: Write a function to cut images to an FFT-suitable pixel number, with a pytest fixture in test_preparation.py.

## Labels and Milestones
  - Label: "data preparation"
  - Milestone: "HW6 - Data Preparation and Analysis"
## Reviewer
  - Suggested reviewer: @kylemasc917
