### PR TITLE
Added the pytest fixtures

### DIFF
--- a/test_preparation.py
+++ b/test_preparation.py
@@ -15,10 +15,8 @@ def sq_img():
         in pandas DataFrame format (e.g., 256x256) with default indexing. """
     # Define size
     pix = 256
-    
     # Generate random pixel intensities for the simulated image (grayscale representation)
     data = np.random.randint(256, size = (pix, pix), dtype = np.uint8)
-    
     # Convert to DataFrame
     return pd.DataFrame(data)
 
@@ -29,9 +27,7 @@ def rect_img():
     # Define size
     pix_x = 512
     pix_y = 256
-    
     # Generate random pixel intensities for the simulated image (grayscale representation)
     data = np.random.randint(256, size = (pix_x, pix_y), dtype = np.uint8)
-    
     # Convert to DataFrame
     return pd.DataFrame(data)

--- a/test_preparation.py
+++ b/test_preparation.py
@@ -1,7 +1,37 @@
-""" unit test template """
+""" This is to test the functions created in the preparation module """
 
+import numpy as np
+import pandas as pd
+import pytest
 import preparation as prep
 
 def test_dummy():
     """ unit test for dummy function """
     assert prep.dummy() == 0
+
+@pytest.fixture
+def sq_img():
+    """ Fixture that returns a 2D square-shaped structure of data
+        in pandas DataFrame format (e.g., 256x256) with default indexing. """
+    # Define size
+    pix = 256
+    
+    # Generate random pixel intensities for the simulated image (grayscale representation)
+    data = np.random.randint(256, size = (pix, pix), dtype = np.uint8)
+    
+    # Convert to DataFrame
+    return pd.DataFrame(data)
+
+@pytest.fixture
+def rect_img():
+    """ Fixture that returns a 2D rectangular-shaped structure of data
+        in pandas DataFrame format (e.g., 512x256) with default indexing. """
+    # Define size
+    pix_x = 512
+    pix_y = 256
+    
+    # Generate random pixel intensities for the simulated image (grayscale representation)
+    data = np.random.randint(256, size = (pix_x, pix_y), dtype = np.uint8)
+    
+    # Convert to DataFrame
+    return pd.DataFrame(data)


### PR DESCRIPTION
# Creating the pytest fixtures
## Linting
  - It 100% lints.

## Contents
  - I defined two functions that generate simulated grayscale images data for square and rectangular images.
  - The data are returned as a pandas data frame with the default indexing (it made since to me in realizing we'll be mainly interested in the periodicity of the positions of lattice points)
  - File Changed: test_preparation.py
  - Changes: the creation of two pytest fixtures

## Reviewer
  - I have no specific suggestion in mind.